### PR TITLE
Fix for an infinite loop when stacking too many frames on caml_roots.

### DIFF
--- a/src/conv.rs
+++ b/src/conv.rs
@@ -314,8 +314,8 @@ unsafe impl<V: ToValue> ToValue for Vec<V> {
         let len = self.len();
         let mut arr = Value::alloc(len, Tag(0));
 
+        crate::local!(x);
         for (i, v) in self.into_iter().enumerate() {
-            crate::local!(x);
             x = v.to_value();
             arr.store_field(i, x);
         }
@@ -381,8 +381,8 @@ unsafe impl<K: ToValue, V: ToValue> ToValue for std::collections::BTreeMap<K, V>
     fn to_value(self) -> Value {
         let mut list = crate::List::empty();
 
+        crate::local!(k_, v_);
         self.into_iter().rev().for_each(|(k, v)| {
-            crate::local!(k_, v_);
             k_ = k.to_value();
             v_ = v.to_value();
             list = list.add((k_, v_));
@@ -413,8 +413,8 @@ unsafe impl<T: ToValue> ToValue for std::collections::LinkedList<T> {
     fn to_value(self) -> Value {
         let mut list = crate::List::empty();
 
+        local!(x);
         self.into_iter().rev().for_each(|t| {
-            local!(x);
             x = t.to_value();
             list = list.add(x);
         });

--- a/test/src/types.ml
+++ b/test/src/types.ml
@@ -14,10 +14,12 @@ let%test "list cons 1" = (list_cons (list_nil ()) 12.5 = [12.5])
 let%test "list cons 2" = (list_cons (list_cons (list_nil ()) 12.5) 11.5 = [11.5; 12.5])
 
 external array_make_range: int -> int -> int array = "array_make_range"
+external array_make_range_f: int -> int -> float array = "array_make_range_f"
 external array_replace: 'a array -> int -> 'a -> 'a option = "array_replace"
 
 let%test "array make range 1" = (array_make_range 0 0 = [||])
-let%test "array make rnage 2" = (array_make_range 0 10 = [|0; 1; 2; 3; 4; 5; 6; 7; 8; 9|])
+let%test "array make range 2" = (array_make_range 0 10 = [|0; 1; 2; 3; 4; 5; 6; 7; 8; 9|])
+let%test "array make range f" = (array_make_range_f 0 50_000 |> Array.length = 50_000)
 let%test "array replace 1" = (
   let a = [| "A"; "B"; "C" |] in
   (array_replace a 1 "X" = (Some "B")) && (a.(1) = "X")

--- a/test/src/types.rs
+++ b/test/src/types.rs
@@ -30,6 +30,11 @@ pub fn array_make_range(
 }
 
 #[ocaml::func]
+pub fn array_make_range_f(start: isize, stop: isize) -> Vec<f64> {
+    (start..stop).map(|x| x as f64).collect()
+}
+
+#[ocaml::func]
 pub fn array_replace(
     mut arr: ocaml::Array<ocaml::Value>,
     index: ocaml::Uint,


### PR DESCRIPTION
First thanks for all the work on this crate!
I think there is an issue with the way intermediate ocaml values are registered as roots to the GC when converting a rust value to an ocaml value. I've added a test that triggers the issue, this happens when converting an array with more than 32768 elements via `ToValue`. On my box, this results in an infinite loop in `caml_oldify_local_roots`.
My guess is that this is caused by calling `local!` too many times, each of these calls adds a frame to caml_roots. A simple fix for this case is to declare the `local!` outside of the various loops (which I guess is fine as on the next loop iteration, the value will be set on another object, e.g. the array, which should be gc protected).