### PR TITLE
Avoid using the local macro.

### DIFF
--- a/derive/src/derive.rs
+++ b/derive/src/derive.rs
@@ -110,11 +110,12 @@ pub fn tovalue_derive(mut s: synstructure::Structure) -> proc_macro::TokenStream
         gen unsafe impl ocaml::ToValue for @Self {
             fn to_value(self) -> ocaml::Value {
                 unsafe {
-                    ocaml::local!(value);
-                    match self {
-                        #(#body),*
-                    }
-                    return value;
+                    ocaml::frame!((value) {
+                        match self {
+                            #(#body),*
+                        }
+                        value
+                    })
                 }
             }
         }

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -127,13 +127,14 @@ macro_rules! tuple_impl {
                     }
                 )*
 
-                crate::local!(v, x);
-                v = $crate::Value::alloc(len, Tag(0));
-                $(
-                    x = $t::to_value(self.$n);
-                    v.store_field($n, x);
-                )*
-                v
+                crate::frame!((v, x) {
+                    v = $crate::Value::alloc(len, Tag(0));
+                    $(
+                        x = $t::to_value(self.$n);
+                        v.store_field($n, x);
+                    )*
+                    v
+                })
             }
         }
     };
@@ -216,11 +217,10 @@ unsafe impl<T: FromValue> FromValue for Option<T> {
 unsafe impl<T: ToValue> ToValue for Option<T> {
     fn to_value(self) -> Value {
         match self {
-            Some(y) => {
-                crate::local!(x);
+            Some(y) => crate::frame!((x) {
                 x = y.to_value();
                 Value::some(x)
-            }
+            }),
             None => Value::none(),
         }
     }
@@ -312,15 +312,16 @@ unsafe impl ToValue for &mut [u8] {
 unsafe impl<V: ToValue> ToValue for Vec<V> {
     fn to_value(self) -> Value {
         let len = self.len();
-        let mut arr = Value::alloc(len, Tag(0));
+        crate::frame!((arr, x) {
+            arr = Value::alloc(len, Tag(0));
 
-        crate::local!(x);
-        for (i, v) in self.into_iter().enumerate() {
-            x = v.to_value();
-            arr.store_field(i, x);
-        }
+            for (i, v) in self.into_iter().enumerate() {
+                x = v.to_value();
+                arr.store_field(i, x);
+            }
 
         arr
+        })
     }
 }
 
@@ -381,14 +382,15 @@ unsafe impl<K: ToValue, V: ToValue> ToValue for std::collections::BTreeMap<K, V>
     fn to_value(self) -> Value {
         let mut list = crate::List::empty();
 
-        crate::local!(k_, v_);
-        self.into_iter().rev().for_each(|(k, v)| {
-            k_ = k.to_value();
-            v_ = v.to_value();
-            list = list.add((k_, v_));
-        });
+        crate::frame!((k_, v_) {
+            self.into_iter().rev().for_each(|(k, v)| {
+                k_ = k.to_value();
+                v_ = v.to_value();
+                list = list.add((k_, v_));
+            });
 
-        list.to_value()
+            list.to_value()
+        })
     }
 }
 
@@ -413,12 +415,13 @@ unsafe impl<T: ToValue> ToValue for std::collections::LinkedList<T> {
     fn to_value(self) -> Value {
         let mut list = crate::List::empty();
 
-        local!(x);
-        self.into_iter().rev().for_each(|t| {
-            x = t.to_value();
-            list = list.add(x);
-        });
-        list.to_value()
+        frame!((x) {
+            self.into_iter().rev().for_each(|t| {
+                x = t.to_value();
+                list = list.add(x);
+            });
+            list.to_value()
+        })
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -289,14 +289,15 @@ impl<T: ToValue + FromValue> List<T> {
     #[must_use]
     #[allow(clippy::should_implement_trait)]
     pub fn add(self, v: T) -> List<T> {
-        local!(x, tmp);
-        x = v.to_value();
-        unsafe {
-            tmp = Value(sys::caml_alloc(2, 0));
-            tmp.store_field(0, x);
-            tmp.store_field(1, self.0);
-        }
-        List(tmp, PhantomData)
+        frame!((x, tmp) {
+                x = v.to_value();
+            unsafe {
+                tmp = Value(sys::caml_alloc(2, 0));
+                tmp.store_field(0, x);
+                tmp.store_field(1, self.0);
+            }
+            List(tmp, PhantomData)
+        })
     }
 
     /// List head


### PR DESCRIPTION
These changes are a follow-up/replacement of my previous pull request, sorry about that.
I looked at the code into a bit more details as I ran into some segfault when using my parquet ocaml wrappers on very large files (code [here](https://github.com/LaurentMazare/ocaml-rust-stubs) if you're curious, maybe we should also discuss the stubs generation bit at some point).

So looking at the macros, it seems that `local!` adds a frame on top of the `local_roots` stack but no equivalent to [CAMLdrop](https://github.com/ocaml/ocaml/blob/d0e0cc82801f8db68f6010b56dd00ade4c42f85b/runtime/caml/memory.h#L468) is ever called. Calling `local!` alone seems to be problematic however there is a nice `frame!` macro which performs the `CAMLdrop` bit in the end.

Maybe I'm missing something but I don't see any place where one would want to use `local!` rather than `frame!`. The current occurences seem problematic so this PR tweak them to use `frame!` instead. This fixed my segfault but sadly that's a bit too large of a use case to add as a test (the parquet file I loaded that triggered this is a couple of GB). Maybe the `local!` macro shouldn't be exposed? Or maybe a `caml_drop` function should also be provided and the documentation would indicate that each `local!` call has to be followed with a `caml_drop`.

Using `frame!` certainly helps but is not a silver bullet. Longer term maybe it would be a good idea to be able to create values only by passing a frame to gc protect them. That's actually the approach from the jlrs crate which provides bindings to julia (the [frame.rs](https://github.com/Taaitaaiger/jlrs/blob/master/jlrs/src/frame.rs) and [stack.rs](https://github.com/Taaitaaiger/jlrs/blob/master/jlrs/src/stack.rs) files are interesting to read), the way to protect values from the gc in julia is very close to the ocaml one so maybe there is some inspiration that could be drawn from there.
