### PR TITLE
Fix the number of tuple arguments + add a test.

### DIFF
--- a/src/conv.rs
+++ b/src/conv.rs
@@ -123,7 +123,7 @@ macro_rules! tuple_impl {
                 $(
                     #[allow(unused)]
                     {
-                        len = $n;
+                        len = $n + 1;
                     }
                 )*
 

--- a/test/src/conv.ml
+++ b/test/src/conv.ml
@@ -92,3 +92,9 @@ let%test "deep clone 1" = (
   let a = [1; 2; 3; 4; 5] in
   deep_clone a = a
 )
+
+external get_pair_vec: unit -> (string * int) array = "pair_vec"
+
+let%test "get-pair-vec" = (
+  get_pair_vec () = [| "foo", 1; "bar", 2 |]
+)

--- a/test/src/conv.rs
+++ b/test/src/conv.rs
@@ -98,3 +98,8 @@ pub unsafe fn deep_clone(a: ocaml::Value) -> ocaml::Value {
     let b = a.deep_clone_to_rust();
     b.deep_clone_to_ocaml()
 }
+
+#[ocaml::func]
+pub fn pair_vec() -> ocaml::Value {
+    vec![("foo", 1), ("bar", 2isize)].to_value()
+}


### PR DESCRIPTION
I think there is a bug in the current conversion from tuple to ocaml values in `conv.rs`. The number of elements that get allocated in the ocaml object is one lower than what it should be as it uses the 'index' of the last macro argument.
This also adds a test that was failing determinstically before and is now fixed (and which I used to debug this).
It would probably be nice to add a lot more tests around moving values between ocaml and rust (and ideally checking that there is no memory leak, that it doesn't fail if there is some gc event, etc...).