### PR TITLE
Use intnat for dimensions of caml_ba_alloc_dims

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -423,7 +423,7 @@ pub mod bigarray {
                         T::kind() | bigarray::Managed::EXTERNAL as i32,
                         1,
                         data.as_mut_ptr() as bigarray::Data,
-                        data.len() as i32,
+                        data.len() as sys::Intnat,
                     ))
                 };
                 x


### PR DESCRIPTION
As per the [compiler code](https://github.com/ocaml/ocaml/blob/d3e73595e55e84250fa77f04e9c239dee1224b7b/runtime/caml/bigarray.h#L114), the dimension parameters should be of type `intnat` rather than `i32` (which is properly done for `bigarray::create`). I haven't seen this creating any error though.