### PR TITLE
Optional OCaml compiler info in env vars when building

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -11,13 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Use OCaml
-      uses: avsm/setup-ocaml@v1.1.1
-      with:
-        ocaml-version: "4.10.0"
 
     - name: Nightly
       run: rustup toolchain install nightly --profile=default
 
     - name: Run clippy
+      env:
+        OCAML_VERSION: 4.09.1
+        OCAML_WHERE_PATH: /ignored
       run: cargo +nightly clippy --all -- -D warnings

--- a/.github/workflows/ocaml.yml
+++ b/.github/workflows/ocaml.yml
@@ -17,11 +17,21 @@ jobs:
         ocaml-version: ["4.11.0", "4.10.0", "4.09.1", "4.08.1", "4.07.0", "4.06.0"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2.0.0
+        uses: actions/checkout@v2
+      - name: OCaml/Opam cache
+        id: ocaml-rs-opam-cache
+        uses: actions/cache@v2
+        with:
+          path: "~/.opam"
+          key: ocaml-rs-opam-${{ matrix.ocaml-version }}-${{ matrix.os }}
       - name: Use OCaml ${{ matrix.ocaml-version }}
-        uses: avsm/setup-ocaml@v1.1.1
+        uses: avsm/setup-ocaml@v1
         with:
           ocaml-version: ${{ matrix.ocaml-version }}
+      - name: Set Opam env
+        run: opam env >> $GITHUB_ENV
+      - name: Add Opam switch to PATH
+        run: opam var bin >> $GITHUB_PATH
       - run: opam install dune ppx_inline_test
       - name: Run OCaml tests
         run: opam exec -- dune runtest --root=./test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,11 +17,21 @@ jobs:
         ocaml-version: ["4.11.0", "4.10.0", "4.09.1", "4.08.1", "4.07.0", "4.06.0"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2.0.0
+        uses: actions/checkout@v2
+      - name: OCaml/Opam cache
+        id: ocaml-rs-opam-cache
+        uses: actions/cache@v2
+        with:
+          path: "~/.opam"
+          key: ocaml-rs-opam-${{ matrix.ocaml-version }}-${{ matrix.os }}
       - name: Use OCaml ${{ matrix.ocaml-version }}
-        uses: avsm/setup-ocaml@v1.0
+        uses: avsm/setup-ocaml@v1
         with:
           ocaml-version: ${{ matrix.ocaml-version }}
+      - name: Set Opam env
+        run: opam env >> $GITHUB_ENV
+      - name: Add Opam switch to PATH
+        run: opam var bin >> $GITHUB_PATH
       - name: Build
         run: cargo build --tests --features=link
       - name: Run Rust tests

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ cargo vendor
 
 then follow the instructions for editing `.cargo/config`
 
+### Build options
+
+By default, building `ocaml-sys` will invoke the `ocamlopt` command to figure out the version and location of the OCaml compiler. There are a few environment variables to control this.
+
+- `OCAMLOPT` (default: `ocamlopt`) is the command that will invoke `ocamlopt`
+- `OCAML_VERSION` (default: result of `$OCAMLOPT -version`) is the target runtime OCaml version.
+- `OCAML_WHERE_PATH` (default: result of `$OCAMLOPT -where`) is the path of the OCaml standard library.
+
+If both `OCAML_VERSION` and `OCAML_WHERE_PATH` are present, their values are used without invoking `ocamlopt`. If any of those two env variables is undefined, then `ocamlopt` will be invoked to obtain both values.
+
+Defining the `OCAML_VERSION` and `OCAML_WHERE_PATH` variables is useful for saving time in CI environments where an OCaml install is not really required (to run `clippy` for example).
+
 ### Features
 
 - `derive`


### PR DESCRIPTION
Makes it possible to build `ocaml-sys` without an OCaml compiler installed.

If **both** `OCAML_VERSION` (= `ocamlopt -version`) and `OCAML_WHERE_PATH` (= `ocamlopt -where`) are present, those values are used instead of calling `ocamlopt`. Otherwise the behavior is the same as before.

@zshipko thoughts on this? probably not terribly useful for end-users, I'm trying to simplify CI for projects that depend on `ocaml-sys` here. Let me know if you have a better idea and I will give it a try.