### PR TITLE
Add without-ocamlopt feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocaml"
-version = "0.18.1"
+version = "0.19.0"
 authors = ["Zach Shipko <zachshipko@gmail.com>"]
 readme = "README.md"
 keywords = ["ocaml", "rust", "ffi"]
@@ -11,11 +11,11 @@ documentation = "https://docs.rs/ocaml"
 edition = "2018"
 
 [package.metadata.docs.rs]
-features = [ "docs-rs", "derive", "link" ]
+features = [ "without-ocamlopt", "derive", "link" ]
 
 [dependencies]
-ocaml-sys = {path = "./sys", version = "0.18.1"}
-ocaml-derive = {path = "./derive", optional = true, version = "0.18"}
+ocaml-sys = {path = "./sys", version = "0.19.0"}
+ocaml-derive = {path = "./derive", optional = true, version = "0.19"}
 cstr_core = {version = "0.2", optional = true}
 ndarray = {version = "^0.13.1", optional = true}
 
@@ -23,7 +23,7 @@ ndarray = {version = "^0.13.1", optional = true}
 default = ["derive"]
 derive = ["ocaml-derive"]
 link = ["ocaml-sys/link"]
-docs-rs = ["ocaml-sys/docs-rs"]
+without-ocamlopt = ["ocaml-sys/without-ocamlopt"]
 no-std = ["cstr_core/alloc"]
 bigarray-ext = ["ndarray"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ default = ["derive"]
 derive = ["ocaml-derive"]
 link = ["ocaml-sys/link"]
 without-ocamlopt = ["ocaml-sys/without-ocamlopt"]
+caml-state = ["ocaml-sys/caml-state"]
 no-std = ["cstr_core/alloc"]
 bigarray-ext = ["ndarray"]
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ This chart contains the mapping between Rust and OCaml types used by `ocaml::fun
 | `f32`            | `float`              |
 | `f64`            | `float`              |
 | `str`            | `string`             |
+| `[u8]`           | `bytes`              |
 | `String`         | `string`             |
 | `Option<A>`      | `'a option`          |
 | `Result<A, B>`   | `exception`          |

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocaml-derive"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["Zach Shipko <zachshipko@gmail.com>"]
 edition = "2018"
 license = "ISC"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ pub type Int = sys::Intnat;
 pub type Uint = sys::Uintnat;
 
 /// Wraps `sys::COMPILER` as `std::process::Command`
-#[cfg(not(feature = "no-std"))]
+#[cfg(not(any(feature = "no-std", feature = "without-ocamlopt")))]
 pub fn ocamlopt() -> std::process::Command {
     std::process::Command::new(sys::COMPILER)
 }

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 cty = "0.2"
 
 [package.metadata.docs.rs]
-features = [ "without-ocamlopt" ]
+features = [ "without-ocamlopt", "caml-state" ]
 
 [features]
 link = []

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocaml-sys"
-version = "0.18.1"
+version = "0.19.0"
 authors = ["Zach Shipko <zachshipko@gmail.com>"]
 keywords = ["ocaml", "rust", "ffi"]
 repository = "https://github.com/zshipko/ocaml-rs"
@@ -13,9 +13,9 @@ edition = "2018"
 cty = "0.2"
 
 [package.metadata.docs.rs]
-features = [ "docs-rs" ]
+features = [ "without-ocamlopt" ]
 
 [features]
 link = []
-docs-rs = []
-
+without-ocamlopt = []
+caml-state = []

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -88,13 +88,23 @@ fn run() -> std::io::Result<()> {
             version = std::str::from_utf8(
                 std::process::Command::new(&ocamlopt)
                     .arg("-version")
-                    .output()?.stdout.as_ref()
-                ).unwrap().trim().to_owned();
+                    .output()?
+                    .stdout
+                    .as_ref(),
+            )
+            .unwrap()
+            .trim()
+            .to_owned();
             ocaml_path = std::str::from_utf8(
                 std::process::Command::new(&ocamlopt)
                     .arg("-where")
-                    .output()?.stdout.as_ref()
-                ).unwrap().trim().to_owned();
+                    .output()?
+                    .stdout
+                    .as_ref(),
+            )
+            .unwrap()
+            .trim()
+            .to_owned();
         }
     }
 
@@ -116,7 +126,7 @@ fn run() -> std::io::Result<()> {
     let major = split[0].parse::<usize>().unwrap();
     let minor = split[1].parse::<usize>().unwrap();
 
-    if major >= 4 && minor >= 10 {
+    if major >= 4 && minor >= 10 || cfg!(feature = "caml-state") {
         // This feature determines whether or not caml_local_roots should
         // use the caml_state struct or the caml_local_roots global
         println!("cargo:rustc-cfg=caml_state");

--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -52,26 +52,14 @@ macro_rules! caml_body {
     }
 }
 
-#[cfg(not(feature = "docs-rs"))]
+#[cfg(not(feature = "without-ocamlopt"))]
 pub const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/ocaml_version"));
 
-#[cfg(feature = "docs-rs")]
-/// OCaml version (4.10.0, 4.09.1, ...)
-pub const VERSION: &str = "";
-
-#[cfg(not(feature = "docs-rs"))]
+#[cfg(not(feature = "without-ocamlopt"))]
 pub const PATH: &str = include_str!(concat!(env!("OUT_DIR"), "/ocaml_path"));
 
-#[cfg(feature = "docs-rs")]
-/// Path to OCaml libraries
-pub const PATH: &str = "";
-
-#[cfg(not(feature = "docs-rs"))]
+#[cfg(not(feature = "without-ocamlopt"))]
 pub const COMPILER: &str = include_str!(concat!(env!("OUT_DIR"), "/ocaml_compiler"));
-
-#[cfg(feature = "docs-rs")]
-/// Path to OCaml compiler
-pub const COMPILER: &str = "";
 
 mod mlvalues;
 #[macro_use]

--- a/sys/src/state.rs
+++ b/sys/src/state.rs
@@ -3,29 +3,35 @@ use crate::{Char, Value};
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[cfg(caml_state)]
 pub struct caml_ref_table {
     pub _address: u8,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[cfg(caml_state)]
 pub struct caml_ephe_ref_table {
     pub _address: u8,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[cfg(caml_state)]
 pub struct caml_custom_table {
     pub _address: u8,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[cfg(caml_state)]
 pub struct longjmp_buffer {
     pub _address: u8,
 }
 
+#[cfg(caml_state)]
 pub type backtrace_slot = *mut ::core::ffi::c_void;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
+#[cfg(caml_state)]
 pub struct caml_domain_state {
     pub _young_ptr: *mut Value,
     pub _young_limit: *mut Value,
@@ -76,12 +82,11 @@ pub struct caml_domain_state {
 
 #[cfg(caml_state)]
 extern "C" {
-
     #[doc(hidden)]
     pub static mut Caml_state: *mut caml_domain_state;
 }
 
-#[cfg(not(caml_state))]
+#[cfg(caml_state)]
 extern "C" {
 
     #[doc(hidden)]
@@ -113,6 +118,7 @@ pub unsafe fn set_local_roots(x: *mut crate::memory::CamlRootsBlock) {
 }
 
 #[test]
+#[cfg(caml_state)]
 fn bindgen_test_layout_caml_domain_state() {
     assert_eq!(
         ::core::mem::size_of::<caml_domain_state>(),

--- a/sys/src/state.rs
+++ b/sys/src/state.rs
@@ -1,4 +1,5 @@
 #![allow(non_camel_case_types)]
+#[allow(unused)]
 use crate::{Char, Value};
 
 #[repr(C)]
@@ -86,7 +87,7 @@ extern "C" {
     pub static mut Caml_state: *mut caml_domain_state;
 }
 
-#[cfg(caml_state)]
+#[cfg(not(caml_state))]
 extern "C" {
 
     #[doc(hidden)]


### PR DESCRIPTION
Also adds `[u8]` to type conversion table in README to fix #45 