### PR TITLE
Expose generational global roots

### DIFF
--- a/sys/src/memory.rs
+++ b/sys/src/memory.rs
@@ -105,4 +105,7 @@ extern "C" {
     pub fn caml_leave_blocking_section();
     pub fn caml_register_global_root(value: *mut Value);
     pub fn caml_remove_global_root(value: *mut Value);
+    pub fn caml_register_generational_global_root(value: *mut Value);
+    pub fn caml_remove_generational_global_root(value: *mut Value);
+    pub fn caml_modify_generational_global_root(value: *mut Value);
 }


### PR DESCRIPTION
This exposes a few functions in ocaml-sys for improved global roots support.

Using the generational roots API, which requires explicit updates,
allows the OCaml runtime to use young and old heaps so that the roots
mostly don't affect minor GC scans.