### PR TITLE
Use `chlorine` for `c_char` type definition

### DIFF
--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/ocaml-sys"
 edition = "2018"
 
 [dependencies]
-cty = "0.2"
+chlorine = "1.0"
 
 [package.metadata.docs.rs]
 features = [ "without-ocamlopt", "caml-state" ]

--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::upper_case_acronyms)]
 #![no_std]
 
-pub type Char = cty::c_char;
+pub type Char = chlorine::c_char;
 
 #[cfg(not(feature = "without-ocamlopt"))]
 pub const VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/ocaml_version"));


### PR DESCRIPTION
Chlorine's c_char matches the c_char from rust stdlib's raw char types.

Closes #65