### PR TITLE
Improve API for working with custom values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## 0.22.0
+
+- Allow `Value` to hold boxroot or raw value
+- Add `Raw::as_value` and `Raw::as_pointer`
+
 ## 0.21.0
 
 - New `Value` implementation to use `ocaml-boxroot-sys`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocaml"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Zach Shipko <zachshipko@gmail.com>"]
 readme = "README.md"
 keywords = ["ocaml", "rust", "ffi"]
@@ -15,9 +15,9 @@ features = [ "without-ocamlopt", "derive", "link" ]
 
 [dependencies]
 ocaml-interop = "0.8"
-ocaml-sys = {path = "./sys", version = "0.21"}
+ocaml-sys = {path = "./sys", version = "0.22"}
 ocaml-boxroot-sys = {version = "0.2"}
-ocaml-derive = {path = "./derive", optional = true, version = "0.21"}
+ocaml-derive = {path = "./derive", optional = true, version = "0.22"}
 cstr_core = {version = "0.2", optional = true}
 ndarray = {version = "^0.15.1", optional = true}
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ use ocaml::FromValue;
 struct MyType;
 
 unsafe extern "C" fn mytype_finalizer(v: ocaml::Raw) {
-    let ptr: ocaml::Pointer<MyType> = ocaml::Pointer::from_value(ocaml::Value::new(v));
+    let ptr = v.as_pointer::<MyType>();
     ptr.drop_in_place()
 }
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocaml-derive"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Zach Shipko <zachshipko@gmail.com>"]
 edition = "2018"
 license = "ISC"

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -102,8 +102,8 @@ unsafe impl<T: 'static + Custom> IntoValue for T {
 /// }
 ///
 /// unsafe extern "C" fn mytype_compare(a: ocaml::Raw, b: ocaml::Raw) -> i32 {
-///     let a: ocaml::Pointer::<MyType> = ocaml::FromValue::from_value(ocaml::Value::new(a));
-///     let b: ocaml::Pointer::<MyType> = ocaml::FromValue::from_value(ocaml::Value::new(b));
+///     let a = a.as_pointer::<MyType>();
+///     let b = b.as_pointer::<MyType>();
 ///
 ///     let a_i = a.as_ref().i;
 ///     let b_i = b.as_ref().i;
@@ -197,8 +197,7 @@ macro_rules! custom {
 /// }
 ///
 /// unsafe extern "C" fn mytype_finalizer(v: ocaml::Raw) {
-///     let v = ocaml::Value::new(v);
-///     let p: ocaml::Pointer<MyType> = ocaml::Pointer::from_value(v);
+///     let p = v.as_pointer::<MyType>();
 ///     p.drop_in_place()
 /// }
 ///

--- a/src/value.rs
+++ b/src/value.rs
@@ -540,6 +540,11 @@ impl Value {
         self.0.modify(v.raw().0);
     }
 
+    /// Modify an OCaml value in place using a raw OCaml value as the new value
+    pub unsafe fn modify_raw<V: IntoValue>(&mut self, v: impl Into<Raw>) {
+        self.0.modify(v.into().0);
+    }
+
     /// Determines if the current value is an exception
     pub unsafe fn is_exception_result(&self) -> bool {
         sys::is_exception_result(self.raw().0)

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocaml-sys"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["Zach Shipko <zachshipko@gmail.com>"]
 keywords = ["ocaml", "rust", "ffi"]
 repository = "https://github.com/zshipko/ocaml-rs"

--- a/test/src/custom.rs
+++ b/test/src/custom.rs
@@ -1,4 +1,4 @@
-use ocaml::{FromValue, Raw, Value};
+use ocaml::Raw;
 
 struct Testing {
     a: ocaml::Float,
@@ -7,10 +7,8 @@ struct Testing {
 }
 
 unsafe extern "C" fn testing_compare(a: Raw, b: Raw) -> i32 {
-    let a = Value::new(a);
-    let b = Value::new(b);
-    let t0 = ocaml::Pointer::<Testing>::from_value(a);
-    let t1 = ocaml::Pointer::<Testing>::from_value(b);
+    let t0 = a.as_pointer::<Testing>();
+    let t1 = b.as_pointer::<Testing>();
     match (t0.as_ref().b, t1.as_ref().b) {
         (x, y) if x == y => 0,
         (x, y) if x < y => -1,
@@ -19,8 +17,7 @@ unsafe extern "C" fn testing_compare(a: Raw, b: Raw) -> i32 {
 }
 
 unsafe extern "C" fn testing_finalize(a: Raw) {
-    let a = Value::new(a);
-    let t0 = ocaml::Pointer::<Testing>::from_value(a);
+    let t0 = a.as_pointer::<Testing>();
     t0.drop_in_place();
 }
 
@@ -59,8 +56,7 @@ struct TestingCallback {
 }
 
 unsafe extern "C" fn testing_callback_finalize(a: ocaml::Raw) {
-    let a = Value::new(a);
-    let t0 = ocaml::Pointer::<TestingCallback>::from_value(a);
+    let t0 = a.as_pointer::<TestingCallback>();
     t0.drop_in_place();
 }
 


### PR DESCRIPTION
- Convert `Value` into an enum to allow references to rooted values to be used as values. This is mostly helpful inside of custom value callbacks where we don't want to allocate a new boxroot and know the value is already rooted.
- Add `Raw::as_value` and `Raw::as_pointer` to simplify custom value functions