### PR TITLE
Expose GC collections functions in ocaml-sys

### DIFF
--- a/sys/src/runtime.rs
+++ b/sys/src/runtime.rs
@@ -6,3 +6,11 @@ extern "C" {
     pub fn caml_shutdown();
     pub fn caml_named_value(name: *const Char) -> *const Value;
 }
+
+/// GC control
+extern "C" {
+    pub fn caml_gc_minor(v: Value);
+    pub fn caml_gc_major(v: Value);
+    pub fn caml_gc_full_major(v: Value);
+    pub fn caml_gc_compaction(v: Value);
+}

--- a/sys/src/runtime.rs
+++ b/sys/src/runtime.rs
@@ -7,7 +7,7 @@ extern "C" {
     pub fn caml_named_value(name: *const Char) -> *const Value;
 }
 
-/// GC control
+// GC control
 extern "C" {
     pub fn caml_gc_minor(v: Value);
     pub fn caml_gc_major(v: Value);

--- a/test/src/runtime.ml
+++ b/test/src/runtime.ml
@@ -83,3 +83,18 @@ let%test "exn" = Util.check_leaks (fun () -> (
   let str = exn_to_string (Invalid_argument "test") in
   str = "Invalid_argument(\"test\")"
 ))
+ 
+external gc_minor: unit -> unit = "gc_minor"
+external gc_major: unit -> unit = "gc_major"
+external gc_full_major: unit -> unit = "gc_full_major"
+external gc_compact: unit -> unit = "gc_compact"
+
+let%test "GC" =
+  Random.init 0;
+  let test f =
+    let i = Random.int 1337 in
+    let s = Int.to_string i in
+    f();
+    s = Int.to_string i
+  in
+  List.for_all test [gc_minor; gc_major; gc_full_major; gc_compact]

--- a/test/src/runtime.ml
+++ b/test/src/runtime.ml
@@ -93,8 +93,8 @@ let%test "GC" =
   Random.init 0;
   let test f =
     let i = Random.int 1337 in
-    let s = Int.to_string i in
+    let s = string_of_int i in
     f();
-    s = Int.to_string i
+    s = string_of_int i
   in
   List.for_all test [gc_minor; gc_major; gc_full_major; gc_compact]

--- a/test/src/runtime.rs
+++ b/test/src/runtime.rs
@@ -96,3 +96,31 @@ pub fn exn_to_string(exn: ocaml::Value) -> String {
         .unwrap()
         .to_owned()
 }
+
+#[ocaml::func]
+pub fn gc_minor() {
+    unsafe {
+        ocaml_sys::caml_gc_minor(ocaml_sys::UNIT);
+    }
+}
+
+#[ocaml::func]
+pub fn gc_major() {
+    unsafe {
+        ocaml_sys::caml_gc_major(ocaml_sys::UNIT);
+    }
+}
+
+#[ocaml::func]
+pub fn gc_full_major() {
+    unsafe {
+        ocaml_sys::caml_gc_full_major(ocaml_sys::UNIT);
+    }
+}
+
+#[ocaml::func]
+pub fn gc_compact() {
+    unsafe {
+        ocaml_sys::caml_gc_compaction(ocaml_sys::UNIT);
+    }
+}


### PR DESCRIPTION
This small PR exposes (some of) the GC's collection hooks, which are useful when testing GC safety in bindings (my main use case here is https://github.com/LaurentMazare/ocaml-rust/pull/1). Surprisingly, I don't see those functions exposed in any header file, but I don't think this is an issue for static linking.  