### PR TITLE
Add support for float arrays

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+- Added support for float arrays in ocaml-sys
+- Renamed `Value::float` to `Value::f64` and `Value::float_val` to `Value::f64_val`
+- Added `Value::alloc_f64_array`, `Value::f64_field` and `Value::store_f64_field`
+
 ## 0.22.4
 
 - Added `Value::exn_to_string` to convert OCaml exception values to their string representation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocaml"
-version = "0.22.4"
+version = "0.23.0"
 authors = ["Zach Shipko <zachshipko@gmail.com>"]
 readme = "README.md"
 keywords = ["ocaml", "rust", "ffi"]
@@ -15,9 +15,9 @@ features = [ "without-ocamlopt", "derive", "link" ]
 
 [dependencies]
 ocaml-interop = "0.8.8"
-ocaml-sys = {path = "./sys", version = "0.22"}
+ocaml-sys = {path = "./sys", version = "0.23"}
 ocaml-boxroot-sys = {version = "0.2"}
-ocaml-derive = {path = "./derive", optional = true, version = "0.22"}
+ocaml-derive = {path = "./derive", optional = true, version = "0.23"}
 cstr_core = {version = "0.2", optional = true}
 ndarray = {version = "^0.15.1", optional = true}
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocaml-derive"
-version = "0.22.0"
+version = "0.23.0"
 authors = ["Zach Shipko <zachshipko@gmail.com>"]
 license = "ISC"
 keywords = ["ocaml-rs", "proc-macro"]

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -195,7 +195,7 @@ unsafe impl<'a, T: FromValue<'a>> FromValue<'a> for Option<T> {
     }
 }
 
-unsafe impl<'a, T: IntoValue> IntoValue for Option<T> {
+unsafe impl<T: IntoValue> IntoValue for Option<T> {
     fn into_value(self, rt: &Runtime) -> Value {
         match self {
             Some(y) => unsafe { Value::some(rt, y) },
@@ -215,7 +215,7 @@ unsafe impl<'a> FromValue<'a> for &'a str {
     }
 }
 
-unsafe impl<'a> IntoValue for &str {
+unsafe impl IntoValue for &str {
     fn into_value(self, _rt: &Runtime) -> Value {
         unsafe { Value::string(self) }
     }
@@ -232,7 +232,7 @@ unsafe impl<'a> FromValue<'a> for &'a mut str {
     }
 }
 
-unsafe impl<'a> IntoValue for &mut str {
+unsafe impl IntoValue for &mut str {
     fn into_value(self, _rt: &Runtime) -> Value {
         unsafe { Value::string(self) }
     }
@@ -248,7 +248,7 @@ unsafe impl<'a> FromValue<'a> for &'a [u8] {
     }
 }
 
-unsafe impl<'a> IntoValue for &[u8] {
+unsafe impl IntoValue for &[u8] {
     fn into_value(self, _rt: &Runtime) -> Value {
         unsafe { Value::bytes(self) }
     }
@@ -264,7 +264,7 @@ unsafe impl<'a> FromValue<'a> for &'a mut [u8] {
     }
 }
 
-unsafe impl<'a> IntoValue for &mut [u8] {
+unsafe impl IntoValue for &mut [u8] {
     fn into_value(self, _rt: &Runtime) -> Value {
         unsafe { Value::bytes(self) }
     }
@@ -325,7 +325,7 @@ array_impl!(31);
 array_impl!(32);
 
 #[cfg(not(feature = "no-std"))]
-unsafe impl<'a, V: IntoValue> IntoValue for Vec<V> {
+unsafe impl<V: IntoValue> IntoValue for Vec<V> {
     fn into_value(self, rt: &Runtime) -> Value {
         let len = self.len();
         let mut arr = unsafe { Value::alloc(len, Tag(0)) };
@@ -442,7 +442,7 @@ unsafe impl<T: IntoValue> IntoValue for std::collections::LinkedList<T> {
     }
 }
 
-unsafe impl<'a> IntoValue for &Value {
+unsafe impl IntoValue for &Value {
     fn into_value(self, _rt: &Runtime) -> Value {
         unsafe { Value::new(self.raw()) }
     }

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -29,13 +29,13 @@ macro_rules! value_f {
     ($t:ty) => {
         unsafe impl IntoValue for $t {
             fn into_value(self, _rt: &Runtime) -> $crate::Value {
-                unsafe { $crate::Value::float(self as crate::Float) }
+                unsafe { $crate::Value::f64(self as crate::Float) }
             }
         }
 
         unsafe impl<'a> FromValue<'a> for $t {
             fn from_value(v: $crate::Value) -> $t {
-                unsafe { v.float_val() as $t }
+                unsafe { v.f64_val () as $t }
             }
         }
     };

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -356,9 +356,11 @@ unsafe impl<'a, V: FromValue<'a>> FromValue<'a> for Vec<V> {
             let len = crate::sys::caml_array_length(v.raw().0);
             let is_double = sys::caml_is_double_array(v.raw().0) == 1 && sys::FLAT_FLOAT_ARRAY;
             let mut dst = Vec::with_capacity(len);
+            let mut tmp = Value::f64(0.0);
             for i in 0..len {
                 if is_double {
-                    dst.push(V::from_value(Value::f64(v.f64_field(i))));
+                    tmp.store_f64_val(v.f64_field(i));
+                    dst.push(V::from_value(Value::new(tmp.raw().0)));
                 } else {
                     dst.push(V::from_value(Value::new(*crate::sys::field(v.raw().0, i))))
                 }

--- a/src/root.rs
+++ b/src/root.rs
@@ -1,6 +1,6 @@
 use crate::sys;
 
-#[derive(Debug, PartialEq, PartialOrd)]
+#[derive(Debug, PartialEq, PartialOrd, Eq)]
 /// Wraps rooted values
 pub struct Root(pub ocaml_boxroot_sys::BoxRoot);
 

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -8,7 +8,7 @@ use crate::sys;
 /// let _ = ocaml::Tag(0);
 /// ```
 #[repr(transparent)]
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Default, Eq)]
 pub struct Tag(pub sys::Tag);
 
 impl From<Tag> for u8 {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,6 @@
+#![allow(unknown_lints)]
+#![allow(clippy::derive_partial_eq_without_eq)]
+
 //! OCaml types represented in Rust, these are zero-copy and incur no additional overhead
 
 use crate::{sys, CamlError, Error, Raw, Runtime, Tag};
@@ -14,7 +17,7 @@ use crate::value::{FromValue, IntoValue, Size, Value};
 ///
 /// This should only be used with values allocated with `alloc_final` or `alloc_custom`,
 /// for abstract pointers see `Value::alloc_abstract_ptr` and `Value::abstract_ptr_val`
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, PartialOrd, Eq)]
 #[repr(transparent)]
 pub struct Pointer<'a, T>(pub Value, PhantomData<&'a T>);
 
@@ -105,7 +108,7 @@ impl<'a, T> AsMut<T> for Pointer<'a, T> {
 }
 
 /// `Array<A>` wraps an OCaml `'a array` without converting it to Rust
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Array<'a, T: IntoValue + FromValue<'a>>(Value, PhantomData<&'a T>);
 
@@ -264,7 +267,7 @@ impl<'a, T: IntoValue + FromValue<'a>> Array<'a, T> {
 
 /// `List<A>` wraps an OCaml `'a list` without converting it to Rust, this introduces no
 /// additional overhead compared to a `Value` type
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct List<'a, T: 'a + IntoValue + FromValue<'a>>(Value, PhantomData<&'a T>);
 
@@ -429,7 +432,7 @@ pub mod bigarray {
     /// OCaml Bigarray.Array1 type, this introduces no
     /// additional overhead compared to a `Value` type
     #[repr(transparent)]
-    #[derive(Clone, PartialEq)]
+    #[derive(Clone, PartialEq, Eq)]
     pub struct Array1<T>(Value, PhantomData<T>);
 
     unsafe impl<'a, T> crate::FromValue<'a> for Array1<T> {
@@ -532,7 +535,7 @@ pub(crate) mod bigarray_ext {
     /// OCaml Bigarray.Array2 type, this introduces no
     /// additional overhead compared to a `Value` type
     #[repr(transparent)]
-    #[derive(Clone, PartialEq)]
+    #[derive(Clone, PartialEq, Eq)]
     pub struct Array2<T>(Value, PhantomData<T>);
 
     impl<T: Copy + Kind> Array2<T> {
@@ -612,7 +615,7 @@ pub(crate) mod bigarray_ext {
     /// OCaml Bigarray.Array3 type, this introduces no
     /// additional overhead compared to a `Value` type
     #[repr(transparent)]
-    #[derive(Clone, PartialEq)]
+    #[derive(Clone, PartialEq, Eq)]
     pub struct Array3<T>(Value, PhantomData<T>);
 
     impl<T: Copy + Kind> Array3<T> {

--- a/src/value.rs
+++ b/src/value.rs
@@ -390,7 +390,7 @@ impl Value {
     }
 
     /// Set index of underlying OCaml double array value
-    pub unsafe fn store_f64_field<V: IntoValue>(&mut self, i: Size, val: f64) {
+    pub unsafe fn store_f64_field(&mut self, i: Size, val: f64) {
         sys::caml_sys_store_double_field(self.raw().0, i, val)
     }
 
@@ -405,7 +405,7 @@ impl Value {
     }
 
     /// Store `f64` in OCaml `Float`
-    pub unsafe fn store_f64_val(&self, val: f64) {
+    pub unsafe fn store_f64_val(&mut self, val: f64) {
         sys::caml_sys_store_double_val(self.raw().0, val)
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -171,6 +171,11 @@ impl Value {
         Value::new(sys::caml_alloc(n, tag.into()))
     }
 
+    /// Allocate a new float array
+    pub unsafe fn alloc_f64_array(n: usize) -> Value {
+        Value::new(sys::caml_alloc_float_array(n))
+    }
+
     /// Allocate a new tuple value
     pub unsafe fn alloc_tuple(n: usize) -> Value {
         Value::new(sys::caml_alloc_tuple(n))
@@ -253,19 +258,19 @@ impl Value {
     /// Allocate and copy a string value
     pub unsafe fn string<S: AsRef<str>>(s: S) -> Value {
         let s = s.as_ref();
-        let value = Value::new(sys::caml_alloc_string(s.len()));
-        let ptr = sys::string_val(value.raw().0);
-        core::ptr::copy_nonoverlapping(s.as_ptr(), ptr, s.len());
-        value
+        Value::new(sys::caml_alloc_initialized_string(
+            s.len(),
+            s.as_ptr() as *const _,
+        ))
     }
 
     /// Allocate and copy a byte array value
     pub unsafe fn bytes<S: AsRef<[u8]>>(s: S) -> Value {
         let s = s.as_ref();
-        let value = Value::new(sys::caml_alloc_string(s.len()));
-        let ptr = sys::string_val(value.raw().0);
-        core::ptr::copy_nonoverlapping(s.as_ptr(), ptr, s.len());
-        value
+        Value::new(sys::caml_alloc_initialized_string(
+            s.len(),
+            s.as_ptr() as *const _,
+        ))
     }
 
     /// Convert from a pointer to an OCaml string back to an OCaml value

--- a/src/value.rs
+++ b/src/value.rs
@@ -6,7 +6,7 @@ use crate::{interop::BoxRoot, root::Root, sys, util, OCaml, OCamlRef, Pointer, R
 pub type Size = sys::Size;
 
 /// Value wraps the native OCaml `value` type
-#[derive(Debug, Clone, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq)]
 pub enum Value {
     /// Rooted value
     Root(Root),
@@ -17,7 +17,7 @@ pub enum Value {
 }
 
 /// Wrapper around sys::Value
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq)]
 #[repr(transparent)]
 pub struct Raw(pub sys::Value);
 
@@ -137,7 +137,7 @@ unsafe impl<T> crate::interop::ToOCaml<T> for Value {
     }
 }
 
-unsafe impl<'a, T> crate::interop::FromOCaml<T> for Value {
+unsafe impl<T> crate::interop::FromOCaml<T> for Value {
     fn from_ocaml(v: OCaml<T>) -> Value {
         unsafe { Value::new(v.raw()) }
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -352,7 +352,7 @@ impl Value {
     }
 
     /// Create an OCaml `Float` from `f64`
-    pub unsafe fn float(d: f64) -> Value {
+    pub unsafe fn f64(d: f64) -> Value {
         Value::new(sys::caml_copy_double(d))
     }
 
@@ -373,10 +373,20 @@ impl Value {
         Value::new(*sys::field(self.raw().0, i))
     }
 
+    /// Get index of underlying OCaml double array value
+    pub unsafe fn f64_field(&self, i: Size) -> f64 {
+        sys::caml_sys_double_field(self.raw().0, i)
+    }
+
     /// Set index of underlying OCaml block value
     pub unsafe fn store_field<V: IntoValue>(&mut self, rt: &Runtime, i: Size, val: V) {
         let v = val.into_value(rt);
         sys::store_field(self.raw().0, i, v.raw().0)
+    }
+
+    /// Set index of underlying OCaml double array value
+    pub unsafe fn store_f64_field<V: IntoValue>(&mut self, i: Size, val: f64) {
+        sys::caml_sys_store_double_field(self.raw().0, i, val)
     }
 
     /// Convert an OCaml `int` to `isize`
@@ -385,8 +395,13 @@ impl Value {
     }
 
     /// Convert an OCaml `Float` to `f64`
-    pub unsafe fn float_val(&self) -> f64 {
-        *(self.raw().0 as *const f64)
+    pub unsafe fn f64_val(&self) -> f64 {
+        sys::caml_sys_double_val(self.raw().0)
+    }
+
+    /// Store `f64` in OCaml `Float`
+    pub unsafe fn store_f64_val(&self, val: f64) {
+        sys::caml_sys_store_double_val(self.raw().0, val)
     }
 
     /// Convert an OCaml `Int32` to `i32`

--- a/sys/Cargo.toml
+++ b/sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocaml-sys"
-version = "0.22.3"
+version = "0.23.0"
 authors = ["Zach Shipko <zachshipko@gmail.com>"]
 keywords = ["ocaml", "rust", "ffi"]
 repository = "https://github.com/zshipko/ocaml-rs"
@@ -14,6 +14,9 @@ cty = "0.2"
 
 [package.metadata.docs.rs]
 features = [ "without-ocamlopt", "caml-state" ]
+
+[build-dependencies]
+cc = "1"
 
 [features]
 default = []

--- a/sys/src/alloc.rs
+++ b/sys/src/alloc.rs
@@ -11,6 +11,7 @@ extern "C" {
     pub fn caml_alloc_small(size: Size, tag: Tag) -> Value;
     pub fn caml_alloc_tuple(size: Size) -> Value;
     pub fn caml_alloc_string(size: Size) -> Value; // size in bytes
+    pub fn caml_alloc_initialized_string(size: Size, string: *const Char) -> Value;
     pub fn caml_copy_string(string: *const Char) -> Value;
     pub fn caml_copy_string_array(arr: *const *const Char) -> Value;
     pub fn caml_is_double_array(v: Value) -> i32;
@@ -18,6 +19,7 @@ extern "C" {
     pub fn caml_copy_int32(int: i32) -> Value; // defined in [ints.c]
     pub fn caml_copy_int64(int: i64) -> Value; // defined in [ints.c]
     pub fn caml_copy_nativeint(int: isize) -> Value; // defined in [ints.c]
+    pub fn caml_alloc_float_array(size: Size) -> Value;
     pub fn caml_alloc_array(
         value: unsafe extern "C" fn(*const Char) -> Value,
         array: *const *const Char,

--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -22,6 +22,12 @@ pub const COMPILER: &str = include_str!(concat!(env!("OUT_DIR"), "/ocaml_compile
 #[cfg(feature = "without-ocamlopt")]
 pub const COMPILER: &str = "";
 
+#[cfg(not(feature = "without-ocamlopt"))]
+pub const FLAT_FLOAT_ARRAY: bool = include!(concat!(env!("OUT_DIR"), "/flat_float_array"));
+
+#[cfg(feature = "without-ocamlopt")]
+pub const FLAT_FLOAT_ARRAY: bool = true;
+
 mod mlvalues;
 #[macro_use]
 mod memory;

--- a/sys/src/mlvalues.rs
+++ b/sys/src/mlvalues.rs
@@ -140,4 +140,8 @@ extern "C" {
     pub fn caml_array_length(value: Value) -> Size;
     pub fn caml_hash_variant(tag: *const u8) -> Value;
     pub fn caml_get_public_method(obj: Value, tag: Value) -> Value;
+    pub fn caml_sys_store_double_val(x: Value, f: f64);
+    pub fn caml_sys_double_val(x: Value) -> f64;
+    pub fn caml_sys_double_field(x: Value, i: Size) -> f64;
+    pub fn caml_sys_store_double_field(x: Value, index: Size, d: f64);
 }

--- a/sys/src/ocaml-sys.c
+++ b/sys/src/ocaml-sys.c
@@ -1,0 +1,10 @@
+#include <caml/mlvalues.h>
+
+void caml_sys_store_double_val(value x, double f) { Store_double_val(x, f); }
+double caml_sys_double_val(value x) { return Double_val(x); }
+
+double caml_sys_double_field(value x, mlsize_t i) { return Double_field(x, i); }
+
+void caml_sys_store_double_field(value x, mlsize_t index, double d) {
+  Store_double_field(x, index, d);
+}

--- a/test/src/runtime.rs
+++ b/test/src/runtime.rs
@@ -63,7 +63,7 @@ pub unsafe fn hash_variant_abc(i: ocaml::Int) -> Value {
 
 #[ocaml::func]
 pub unsafe fn hash_variant_def(i: ocaml::Float) -> Value {
-    let f = Some(Value::float(i));
+    let f = Some(Value::f64(i));
     Value::hash_variant(gc, "Def", f)
 }
 


### PR DESCRIPTION
- Defines [ocaml_sys::FLAT_FLOAT_ARRAY](https://github.com/zshipko/ocaml-rs/blob/float-array/sys/src/lib.rs#L26)
- Adds [sys/src/ocaml-sys.c](https://github.com/zshipko/ocaml-rs/blob/float-array/sys/src/ocaml-sys.c) which contains wrappers for Double_val, Store_double_val, Double_field and Store_double_field (see https://github.com/zshipko/ocaml-rs/blob/float-array/sys/src/mlvalues.rs#L143)
- Adds `ocaml_sys::caml_alloc_float_array`