### PR TITLE
Fixes no_std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,6 @@ pub use crate::tag::Tag;
 pub use crate::types::{bigarray, Array, List, Seq};
 pub use crate::value::{FromValue, Raw, ToValue, Value};
 
-#[cfg(not(feature = "no-std"))]
 pub use crate::macros::initial_setup;
 
 /// OCaml `float`

--- a/src/types.rs
+++ b/src/types.rs
@@ -30,7 +30,7 @@ unsafe impl<T: FromValue> FromValue for Seq<T> {
     }
 }
 
-impl<T: FromValue> std::iter::Iterator for Seq<T> {
+impl<T: FromValue> core::iter::Iterator for Seq<T> {
     type Item = Result<T, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {


### PR DESCRIPTION
`initial_setup` already appears to be internally gated to be `no_std` compatible so the `cfg` for the root export was removed.