### PR TITLE
Feature gate panic hook

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,10 @@ without-ocamlopt = [
   "ocaml-boxroot-sys/without-ocamlopt"
 ]
 caml-state = ["ocaml-sys/caml-state"]
-no-std = ["cstr_core/alloc"]
+no-std = ["cstr_core/alloc", "no-panic-hook"]
 bigarray-ext = ["ndarray"]
 no-caml-startup = ["ocaml-interop/no-caml-startup"]
+no-panic-hook = []
 
 [workspace]
 members = [

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -19,7 +19,7 @@ pub fn initial_setup() {
         ocaml_boxroot_sys::boxroot_setup();
     }
 
-    #[cfg(not(feature = "no-std"))]
+    #[cfg(not(feature = "no-panic-hook"))]
     {
         ::std::panic::set_hook(Box::new(|info| unsafe {
             let err = info.payload();


### PR DESCRIPTION
Allows disabling setting the panic hook via the `no-panic-hook` feature. Disabled by default so existing users should not observe any changes. Required by the `no-std` feature.