### PR TITLE
Test `no_std` feature in CI

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -2,21 +2,38 @@ name: Clippy
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
+  stylecheck:
+    name: Stylecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install stable toolchain with rustfmt and run cargo format in check mode
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: rustfmt
+          override: true
+
+      - run: cargo fmt --all -- --check
+
   clippy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Nightly
-      run: rustup toolchain install nightly --profile=default
+      - name: Nightly
+        run: rustup toolchain install nightly --profile=default
 
-    - name: Run clippy
-      env:
-        OCAML_VERSION: 4.13.1
-        OCAML_WHERE_PATH: /ignored
-      run: sudo apt install ocaml && cargo +nightly clippy --features=without-ocamlopt --all -- -D warnings
+      - name: Run clippy
+        env:
+          OCAML_VERSION: 4.13.1
+          OCAML_WHERE_PATH: /ignored
+        run: sudo apt install ocaml && cargo +nightly clippy --features=without-ocamlopt --all -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   run:
@@ -14,31 +14,54 @@ jobs:
       fail-fast: true
       matrix:
         os: [macos-latest, ubuntu-latest]
-        ocaml-compiler: ["4.14.0", "4.13.1", "4.12.1", "4.11.0", "4.10.0", "4.09.1", "4.08.1", "4.07.0"]
+        ocaml-compiler:
+          [
+            "4.14.0",
+            "4.13.1",
+            "4.12.1",
+            "4.11.0",
+            "4.10.0",
+            "4.09.1",
+            "4.08.1",
+            "4.07.0",
+          ]
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
       - name: OCaml/Opam cache
         id: ocaml-rs-opam-cache
         uses: actions/cache@v2
         with:
           path: "~/.opam"
           key: ocaml-rs-opam-${{ matrix.ocaml-compiler }}-${{ matrix.os }}
+
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: avsm/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
       - name: Set Opam env
         run: opam env | tr '\n' ' ' >> $GITHUB_ENV
+
       - name: Add Opam switch to PATH
         run: opam var bin >> $GITHUB_PATH
+
       - name: Install mdbook
         run: cargo install mdbook
+
       - name: Build
         run: cargo build --tests --features=link
+
       - name: Build build
         run: cargo build --package ocaml-build --features=dune
+
       - name: Run Rust tests
         run: cargo test --features=link -- --test-threads=1
+
       - name: Check mdbook
         run: mdbook test doc -L ./target/debug/deps
+
+      - name: Test `no_std`
+        run: cargo build --tests --features=no-std


### PR DESCRIPTION
Adds `rustfmt` check in Clippy workflow, adds test in Rust workflow for testing `no-std` feature. Will push commit on this branch that breaks the feature to test that CI fails, then remove.