### PR TITLE
Updating github workflow

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -15,12 +15,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install stable toolchain with rustfmt and run cargo format in check mode
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           toolchain: stable
-          components: rustfmt
-          override: true
 
       - run: cargo fmt --all -- --check
 
@@ -29,9 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Nightly
+      - name: Stable
         run: rustup toolchain install stable --profile=default
-      
+
       - name: Use OCaml
         uses: ocaml/setup-ocaml@v2
         with:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install stable toolchain with rustfmt and run cargo format in check mode
         uses: dtolnay/rust-toolchain@v1
@@ -24,7 +24,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Stable
         run: rustup toolchain install stable --profile=default

--- a/.github/workflows/ocaml.yml
+++ b/.github/workflows/ocaml.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: OCaml/Opam cache
         id: ocaml-rs-opam-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: "~/.opam"
           key: ocaml-rs-opam-${{ matrix.ocaml-compiler }}-${{ matrix.os }}
@@ -63,4 +63,3 @@ jobs:
         #      - run: opam install dune ppx_inline_test notty bechamel-notty
         #      - name: Run OCaml tests
         #        run: opam exec -- dune exec --root=./test src/bench.exe
-

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,11 +28,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: OCaml/Opam cache
         id: ocaml-rs-opam-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: "~/.opam"
           key: ocaml-rs-opam-${{ matrix.ocaml-compiler }}-${{ matrix.os }}


### PR DESCRIPTION
Hello!

I was looking through the code again and I noticed that some of the github workflow actions were out of date(atleast relating to some of the rust ones). I'm submitting this pr as a quick fix for these.

- I'll note that actions-rs is largely considered unmaintained. I've followed in the footsteps of burntsushi and swapped this with dtolnay's version which has up to date support. https://github.com/rust-lang/regex/pull/883
- Depending on your interest, you can also set dependabot to also work with github actions https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates#supported-repositories-and-ecosystems