### PR TITLE
Fix bug where `Vec<f32>` would be converted to a non-flat float array in ocaml

### DIFF
--- a/src/conv.rs
+++ b/src/conv.rs
@@ -328,7 +328,10 @@ unsafe impl<V: 'static + ToValue> ToValue for Vec<V> {
     fn to_value(&self, rt: &Runtime) -> Value {
         let len = self.len();
 
-        if core::any::TypeId::of::<f64>() == core::any::TypeId::of::<V>() && sys::FLAT_FLOAT_ARRAY {
+        if (core::any::TypeId::of::<f32>() == core::any::TypeId::of::<V>()
+            || core::any::TypeId::of::<f64>() == core::any::TypeId::of::<V>())
+            && sys::FLAT_FLOAT_ARRAY
+        {
             let mut arr = unsafe { Value::alloc_double_array(len) };
             for (i, v) in self.iter().enumerate() {
                 unsafe {

--- a/test/src/conv.ml
+++ b/test/src/conv.ml
@@ -106,3 +106,24 @@ let%test "floatarray_t" = Util.check_leaks (fun () ->
   let a = Rust.{fa = Float.Array.of_list [ 1.0; 2.0; 3.0; ]} in
   let b = Rust.float_array_t_inner a in
   a.fa = b)
+
+(* Tests that arrays generated in rust can be indexed into from ocaml *)
+let%test "index into int array" = Util.check_leaks (fun () ->
+  let arr = Rust.make_int32_array_012 () in
+  List.for_all (fun i -> Int32.to_int (Array.get arr i) = i) [0; 1; 2])
+
+let%test "index float array f32" = Util.check_leaks (fun () ->
+  let arr = Rust.make_float_array_f32_012 () in
+  List.for_all (fun i -> Array.get arr i = Float.of_int i) [0; 1; 2])
+
+let%test "index floatarray f32" = Util.check_leaks (fun () ->
+  let arr = Rust.make_floatarray_f32_012 () in
+  List.for_all (fun i -> Float.Array.get arr i = Float.of_int i) [0; 1; 2])
+
+let%test "index float array f64" = Util.check_leaks (fun () ->
+  let arr = Rust.make_float_array_f64_012 () in
+  List.for_all (fun i -> Array.get arr i = Float.of_int i) [0; 1; 2])
+
+let%test "index floatarray f64" = Util.check_leaks (fun () ->
+  let arr = Rust.make_floatarray_f64_012 () in
+  List.for_all (fun i -> Float.Array.get arr i = Float.of_int i) [0; 1; 2])

--- a/test/src/conv.rs
+++ b/test/src/conv.rs
@@ -198,3 +198,34 @@ pub struct FloatArrayT {
 pub fn float_array_t_inner(f: FloatArrayT) -> Vec<f64> {
     f.arr
 }
+
+#[ocaml::func]
+#[ocaml::sig("unit -> int32 array")]
+pub fn make_int32_array_012() -> Vec<i32> {
+    println!("make_int32_012");
+    vec![0, 1, 2]
+}
+
+#[ocaml::func]
+#[ocaml::sig("unit -> float array")]
+pub fn make_float_array_f32_012() -> Vec<f32> {
+    vec![0.0, 1.0, 2.0]
+}
+
+#[ocaml::func]
+#[ocaml::sig("unit -> floatarray")]
+pub fn make_floatarray_f32_012() -> Vec<f32> {
+    vec![0.0, 1.0, 2.0]
+}
+
+#[ocaml::func]
+#[ocaml::sig("unit -> float array")]
+pub fn make_float_array_f64_012() -> Vec<f64> {
+    vec![0.0, 1.0, 2.0]
+}
+
+#[ocaml::func]
+#[ocaml::sig("unit -> floatarray")]
+pub fn make_floatarray_f64_012() -> Vec<f64> {
+    vec![0.0, 1.0, 2.0]
+}

--- a/test/src/rust.ml
+++ b/test/src/rust.ml
@@ -36,6 +36,11 @@ external result_get_ok: ('a, 'b) result -> 'a option = "result_get_ok"
 external result_get_error: ('a, 'b) result -> 'b option = "result_get_error"
 external all_float_struct_inc_both: all_float_struct -> all_float_struct = "all_float_struct_inc_both"
 external float_array_t_inner: float_array_t -> floatarray = "float_array_t_inner"
+external make_int32_array_012: unit -> int32 array = "make_int32_array_012"
+external make_float_array_f32_012: unit -> float array = "make_float_array_f32_012"
+external make_floatarray_f32_012: unit -> floatarray = "make_floatarray_f32_012"
+external make_float_array_f64_012: unit -> float array = "make_float_array_f64_012"
+external make_floatarray_f64_012: unit -> floatarray = "make_floatarray_f64_012"
 
 (* file: custom.rs *)
 

--- a/test/src/rust.mli
+++ b/test/src/rust.mli
@@ -36,6 +36,11 @@ external result_get_ok: ('a, 'b) result -> 'a option = "result_get_ok"
 external result_get_error: ('a, 'b) result -> 'b option = "result_get_error"
 external all_float_struct_inc_both: all_float_struct -> all_float_struct = "all_float_struct_inc_both"
 external float_array_t_inner: float_array_t -> floatarray = "float_array_t_inner"
+external make_int32_array_012: unit -> int32 array = "make_int32_array_012"
+external make_float_array_f32_012: unit -> float array = "make_float_array_f32_012"
+external make_floatarray_f32_012: unit -> floatarray = "make_floatarray_f32_012"
+external make_float_array_f64_012: unit -> float array = "make_float_array_f64_012"
+external make_floatarray_f64_012: unit -> floatarray = "make_floatarray_f64_012"
 
 (* file: custom.rs *)
 


### PR DESCRIPTION
This changes the treatment of `Vec<f32>` to be the same as that of `Vec<f64>` and adds some tests creating `Vec`s in rust and then indexing into the resulting `array`s in ocaml.