### PR TITLE
Hide ocaml state behind `caml-state` feature flag

### DIFF
--- a/sys/src/lib.rs
+++ b/sys/src/lib.rs
@@ -38,6 +38,7 @@ mod custom;
 mod fail;
 mod printexc;
 mod runtime;
+#[cfg(feature = "caml-state")]
 mod state;
 mod tag;
 
@@ -51,5 +52,6 @@ pub use memory::*;
 pub use mlvalues::*;
 pub use printexc::*;
 pub use runtime::*;
+#[cfg(feature = "caml-state")]
 pub use state::*;
 pub use tag::*;


### PR DESCRIPTION
I had to disable `state.rs` compilation in order to build with ocaml 5.2. It doesn't seem to be used anywhere inside ocaml-rs and I've seen a mention of this feature flag in ocaml-interop. I'm not sure if `caml-state` was added in Cargo.toml and not in rust files or it's a different feature after all.